### PR TITLE
Allow deploys to servers while initialization is occurring

### DIFF
--- a/lib/cap-ec2/ec2-handler.rb
+++ b/lib/cap-ec2/ec2-handler.rb
@@ -97,7 +97,7 @@ module CapEC2
       @ec2.any? do |_, ec2|
         ec2.describe_instance_status(
           instance_ids: [instance.instance_id],
-          filters: [{ name: 'instance-status.status', values: %w(ok) }]
+          filters: [{ name: 'instance-status.status', values: %w(ok initializing) }]
         ).instance_statuses.length == 1
       end
     end


### PR DESCRIPTION
We use `cap-ec2` in conjunction with `ec2` autoscaling. As mentioned in the `README`, it takes a while for just-launched instances to make it to the `OK` status. This change makes it so that deploys can happen while they are still in an `initializing` state.

The problem with turning off `filter_by_status_ok?` completely is that trying to deploy to instances while they are `terminating` can cause a Capistrano deploy to hang indefinitely while it waits for a ssh connection that will never come. When triggering a deploy due to an auto-scaling action, there is almost always a terminating instance and an initializing instance at the same time.